### PR TITLE
multi tweet support

### DIFF
--- a/gameideamachine.js
+++ b/gameideamachine.js
@@ -80,7 +80,7 @@ function monitor() {
 		// ignore everything other than "@gameidemachine command" (for now)
 		if(message.indexOf('@gameideamachine') !== 0) { return; }
 
-		var command = message.replace('@gameideamachine','').trim().toLowerCase();
+		var command = message.replace('@gameideamachine','').trim().toLowerCase().split(' ')[0];
 
 		if(command === 'idea') {
 			reply(tweet, generator.generateSafe(null, tweet.user.screen_name));


### PR DESCRIPTION
Twitter doesn't allow tweeting the same message twice; if a user wants two e.g. bosses, or a different suggestion they can't send the same 'command'. Splitting the string in this change would allow a unique tweet to be processed.

@gameideamachine boss
@gameideamachine boss 2
